### PR TITLE
Add avatar-emojis to message-sending

### DIFF
--- a/pkg/rocketchat/client.go
+++ b/pkg/rocketchat/client.go
@@ -21,6 +21,7 @@ type Message struct {
 	Text    string `json:"text"`
 	Channel string `json:"channel"`
 	Alias   string `json:"alias,omitempty"`
+	Emoji   string `json:"emoji,omitempty"`
 }
 
 // User represents a user in Rocket.Chat
@@ -103,11 +104,12 @@ func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 	return resp, err
 }
 
-func (c *Client) SendMessage(channel, text, alias string) error {
+func (c *Client) SendMessage(channel, text, alias string, emoji string) error {
 	msg := &Message{
 		Text:    text,
 		Channel: channel,
 		Alias:   alias,
+		Emoji:   emoji,
 	}
 
 	req, err := c.newRequest("POST", "/api/v1/chat.postMessage", msg)

--- a/send.go
+++ b/send.go
@@ -7,6 +7,7 @@ import (
 func newSendMsgCmd(app *app) *cobra.Command {
 	var (
 		alias string
+		emoji string
 	)
 	cmd := &cobra.Command{
 		Use:   "send <user|channel> <message>",
@@ -21,10 +22,11 @@ func newSendMsgCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			destination := args[0]
 			message := args[1]
-			return app.client.SendMessage(destination, message, alias)
+			return app.client.SendMessage(destination, message, alias, emoji)
 		},
 	}
 	cmd.Flags().StringVar(&alias, "alias", alias, "Name under which the message appears.")
+	cmd.Flags().StringVar(&emoji, "emoji", emoji, "Change the Avatar to an emoji, e.g. :smirk:")
 	return cmd
 }
 


### PR DESCRIPTION
You can now add the `--emoji` flag as defined per the Rocket Chat API.